### PR TITLE
Fix violations of Sonar rule 2142

### DIFF
--- a/MyPerf4J-Base/src/main/java/cn/myperf4j/base/util/concurrent/ExecutorManager.java
+++ b/MyPerf4J-Base/src/main/java/cn/myperf4j/base/util/concurrent/ExecutorManager.java
@@ -31,6 +31,7 @@ public final class ExecutorManager {
                 executorService.awaitTermination(timeout, unit);
             } catch (InterruptedException e) {
                 Logger.error("ExecutorManager.stopAll()", e);
+                Thread.currentThread().interrupt();
             }
         }
     }


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2142: '"InterruptedException" should not be ignored'](https://rules.sonarsource.com/java/RSPEC-2142).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2142](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#interruptedexception-should-not-be-ignored-sonar-rule-2142).