### PR TITLE
Fix violations of Sonar rule 2184

### DIFF
--- a/MyPerf4J-Base/src/main/java/cn/myperf4j/base/util/concurrent/MyAtomicIntArray.java
+++ b/MyPerf4J-Base/src/main/java/cn/myperf4j/base/util/concurrent/MyAtomicIntArray.java
@@ -139,6 +139,6 @@ public final class MyAtomicIntArray implements Serializable {
 
     public void reset() {
         final int[] array = this.array;
-        unsafe.setMemory(array, byteOffset(0), array.length * scale, (byte) 0);
+        unsafe.setMemory(array, byteOffset(0), (long) array.length * scale, ((byte) (0)));
     }
 }

--- a/MyPerf4J-Base/src/main/java/cn/myperf4j/base/util/concurrent/MyAtomicIntArray.java
+++ b/MyPerf4J-Base/src/main/java/cn/myperf4j/base/util/concurrent/MyAtomicIntArray.java
@@ -139,6 +139,6 @@ public final class MyAtomicIntArray implements Serializable {
 
     public void reset() {
         final int[] array = this.array;
-        unsafe.setMemory(array, byteOffset(0), (long) array.length * scale, ((byte) (0)));
+        unsafe.setMemory(array, byteOffset(0), (long) array.length * scale, (byte) 0);
     }
 }


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2184: 'Math operands should be cast before assignment'](https://rules.sonarsource.com/java/RSPEC-2184).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2184](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#math-operands-should-be-cast-before-assignment-sonar-rule-2184).