### PR TITLE
[MyPerf4J-87] Fix windows env getConfigFileDir is empty #87

### DIFF
--- a/MyPerf4J-Core/src/main/java/cn/myperf4j/core/AbstractBootstrap.java
+++ b/MyPerf4J-Core/src/main/java/cn/myperf4j/core/AbstractBootstrap.java
@@ -172,7 +172,7 @@ public abstract class AbstractBootstrap {
             Properties properties = new Properties();
             properties.load(in);
 
-            properties.put(PROPERTIES_FILE_DIR.key(), getConfigFileDir(configFilePath));
+            properties.put(PROPERTIES_FILE_DIR.key(), parseConfigFileDir(configFilePath));
             return MyProperties.initial(properties);
         } catch (IOException e) {
             Logger.error("AbstractBootstrap.initProperties()", e);
@@ -180,7 +180,7 @@ public abstract class AbstractBootstrap {
         return false;
     }
 
-    private String getConfigFileDir(String configFilePath) {
+    private String parseConfigFileDir(String configFilePath) {
         final int idx = configFilePath.lastIndexOf(File.separatorChar);
         return configFilePath.substring(0, idx + 1);
     }

--- a/MyPerf4J-Core/src/main/java/cn/myperf4j/core/AbstractBootstrap.java
+++ b/MyPerf4J-Core/src/main/java/cn/myperf4j/core/AbstractBootstrap.java
@@ -181,12 +181,7 @@ public abstract class AbstractBootstrap {
     }
 
     private String getConfigFileDir(String configFilePath) {
-        if (System.getProperty("os.name").startsWith("windows")) {
-            final int idx = configFilePath.lastIndexOf('\\');
-            return configFilePath.substring(0, idx + 1);
-        }
-
-        final int idx = configFilePath.lastIndexOf('/');
+        final int idx = configFilePath.lastIndexOf(File.separatorChar);
         return configFilePath.substring(0, idx + 1);
     }
 

--- a/MyPerf4J-Core/src/test/java/cn/myperf4j/core/SystemPropertiesTest.java
+++ b/MyPerf4J-Core/src/test/java/cn/myperf4j/core/SystemPropertiesTest.java
@@ -1,6 +1,9 @@
 package cn.myperf4j.core;
 
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.File;
 
 /**
  * Created by LinShunkang on 2019/07/28
@@ -9,6 +12,23 @@ public class SystemPropertiesTest {
 
     @Test
     public void test() {
+        // windows下os.name的返回值是以 Windows 开头的
+        Assert.assertFalse(System.getProperty("os.name").startsWith("windows"));
+        String configFilePath;
+        final boolean windows = System.getProperty("os.name").toLowerCase().startsWith("windows");
+        if (windows) {
+            configFilePath = "C:\\path\\to\\MyPerf4J.properties";
+        } else {
+            configFilePath = "/path/to/MyPerf4J.properties";
+        }
+        final int idx = configFilePath.lastIndexOf(File.separatorChar);
+        configFilePath = configFilePath.substring(0, idx + 1);
+        if (windows) {
+            Assert.assertEquals(configFilePath, "C:\\path\\to\\");
+        } else {
+            Assert.assertEquals(configFilePath, "/path/to/");
+        }
+
         System.out.println(System.getProperty("os.name"));
         System.out.println(System.getProperty("file.separator"));
         System.out.println(System.getProperty("path.separator"));

--- a/MyPerf4J-Core/src/test/java/cn/myperf4j/core/SystemPropertiesTest.java
+++ b/MyPerf4J-Core/src/test/java/cn/myperf4j/core/SystemPropertiesTest.java
@@ -12,10 +12,20 @@ public class SystemPropertiesTest {
 
     @Test
     public void test() {
+        System.out.println(System.getProperty("os.name"));
+        System.out.println(System.getProperty("file.separator"));
+        System.out.println(System.getProperty("path.separator"));
+        System.out.println(System.getProperty("line.separator"));
+    }
+
+    @Test
+    public void testParseConfigFileDir() {
         // windows下os.name的返回值是以 Windows 开头的
-        Assert.assertFalse(System.getProperty("os.name").startsWith("windows"));
+        final String osName = System.getProperty("os.name");
+        Assert.assertFalse(osName.startsWith("windows"));
+
         String configFilePath;
-        final boolean windows = System.getProperty("os.name").toLowerCase().startsWith("windows");
+        final boolean windows = osName.toLowerCase().startsWith("windows");
         if (windows) {
             configFilePath = "C:\\path\\to\\MyPerf4J.properties";
         } else {
@@ -28,11 +38,6 @@ public class SystemPropertiesTest {
         } else {
             Assert.assertEquals(configFilePath, "/path/to/");
         }
-
-        System.out.println(System.getProperty("os.name"));
-        System.out.println(System.getProperty("file.separator"));
-        System.out.println(System.getProperty("path.separator"));
-        System.out.println(System.getProperty("line.separator"));
     }
 
 }


### PR DESCRIPTION
## What is the purpose of the change

fix #87

## Brief ChangeLog

Fix windows env getConfigFileDir is empty

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/LinShunKang/MyPerf4J/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[MyPerf4J-XXX] Fix NullPointerException when host is null #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist.
- [x] Run `mvn clean package -Dmaven.test.skip=false` to make sure unit-test pass.