### PR TITLE
Add toString() to ConfigKey for readable log output

### DIFF
--- a/MyPerf4J-Base/src/main/java/cn/myperf4j/base/config/ConfigKey.java
+++ b/MyPerf4J-Base/src/main/java/cn/myperf4j/base/config/ConfigKey.java
@@ -25,4 +25,12 @@ public final class ConfigKey {
     public static ConfigKey of(String key, String legacyKey) {
         return new ConfigKey(key, legacyKey);
     }
+
+    @Override
+    public String toString() {
+        return "ConfigKey{" +
+                "key='" + key + '\'' +
+                ", legacyKey='" + legacyKey + '\'' +
+                '}';
+    }
 }


### PR DESCRIPTION
## Summary

- Add `toString()` override to `ConfigKey` so log statements render the key and legacyKey fields instead of the default object hash
- Produces output like `ConfigKey{key='...', legacyKey='...'}` for debugging and configuration troubleshooting

## Test plan

- [ ] Verify `ConfigKey.of("k", "lk").toString()` returns `ConfigKey{key='k', legacyKey='lk'}`
- [ ] Confirm existing tests still pass